### PR TITLE
Feat/create handle_connection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
 use std::net::TcpListener;
+use std::io::prelude::BufRead;
+use std::io::*;
+use std::net::TcpStream;
 
 fn main() {
     let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
@@ -6,6 +9,17 @@ fn main() {
     for stream in listener.incoming() {
         let stream = stream.unwrap();
 
-        println!("Connection established");
+        handle_connection(stream);
     }
+}
+
+fn handle_connection(mut stream: TcpStream) {
+    let buf_reader = BufReader::new(&mut stream);
+    let http_request: Vec<_> = buf_reader
+        .lines()
+        .map(|result| result.unwrap())
+        .take_while(|line| !line.is_empty())
+        .collect();
+
+    println!("Request: {http_request:#?}")
 }


### PR DESCRIPTION
 - the handle_connection function is created, which displays port requests to the console, using buf_reader, which records the stream of requests sent to the server.

 - http_request acts as a parser that takes everything from the buffer and returns the data as a vector.